### PR TITLE
use application config

### DIFF
--- a/src/commands/PullPackage.ts
+++ b/src/commands/PullPackage.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable no-unused-vars */
 
+import { app } from '../Application';
 import { Command } from './Command';
 import { GitUtilties } from '../lib/GitUtilties';
-import { config } from '../Configuration';
 
 export default class PullPackageCommand extends Command {
     public static command = 'pull-package <name>';
@@ -14,6 +14,7 @@ export default class PullPackageCommand extends Command {
 
     static handle(argv: any): void {
         const name = argv.name;
+        const config = app.configuration;
 
         GitUtilties.displayStatusMessages = true;
 

--- a/src/commands/PullTemplate.ts
+++ b/src/commands/PullTemplate.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 
+import { app } from '../Application';
 import { Command } from './Command';
-import { config } from '../Configuration';
 import { GitUtilties } from '../lib/GitUtilties';
 
 export default class PullTemplateCommand extends Command {
@@ -13,6 +13,7 @@ export default class PullTemplateCommand extends Command {
 
     static handle(argv: any): void {
         const argvName = argv.name ?? '';
+        const config = app.configuration;
 
         const shortTemplateName = (longName: string) => {
             return longName.split('-')


### PR DESCRIPTION
Hi! Thanks for the package!

When trying to run the `analyze` command with my own config file I found that the config is not shared throughout. It seems like the Application instance holds and manages its own configuration instance which is not necessarily the same config instance that will be imported directly from the configuration file.

In this patch I've just adjusted the relevant commands to grab the config off the application instance. Let me know if you think a bigger change makes sense to ensure all config is pulled from the app instance rather than the config file.

I also haven't added any tests, I wasn't sure what the best way to test this would be. Let me know if this needs a test to proceed with.

Thanks